### PR TITLE
[src/{lib,unix}.rs] Fix comparison asserts by using correct type ; [README.md] `fast_fail` => `check_env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ this feature, replace the above lines in the `Cargo.toml` with
 
 ```toml
 [dependencies]
-homedir = { version = "0.1.0", features = ["fast_fail"] }
+homedir = { version = "0.1.0", features = ["check_env"] }
 ```
 
 This feature is only useful on Unix systems; it has no effect on Windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! homedir = { version = '0.1.0", features = ["fast_fail"] }
+//! homedir = { version = '0.1.0", features = ["check_env"] }
 //! ```
 //!
 //! This feature is only useful on Unix systems; it has no effect on Windows.
@@ -45,7 +45,7 @@
 //!
 //! // This assumes that the process' user has "/home/jpetersen" as home directory.
 //! assert_eq!(
-//!     "/home/jpetersen".as_ref(),
+//!     std::path::Path::new("/home/jpetersen"),
 //!     get_my_home().unwrap().unwrap().as_path()
 //! );
 //! ```
@@ -57,7 +57,7 @@
 //! // This assumes there is a user named `Administrator` which has
 //! // `C:\Users\Administrator` as a home directory.
 //! assert_eq!(
-//!     "C:\\Users\\Administrator".as_ref(),
+//!     std::path::Path::new("C:\\Users\\Administrator"),
 //!     get_home("Administrator").unwrap().unwrap().as_path()
 //! );
 //! assert!(get_home("NonExistentUser").unwrap().is_none());

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -26,8 +26,8 @@ pub type GetHomeError = nix::errno::Errno;
 /// // This assumes there is a user named `root` which has
 /// // `/root` as a home directory.
 /// assert_eq!(
-///     "/root".as_ref(),
-///     get_home("root").unwrap().unwrap().as_path()
+///     std::path::Path::new("/root"),
+///     get_home("root").unwrap().unwrap()
 /// );
 /// assert!(get_home("nonexistentuser").unwrap().is_none());
 /// ```
@@ -53,7 +53,7 @@ pub fn get_home<S: AsRef<str>>(username: S) -> Result<Option<PathBuf>, GetHomeEr
 ///
 /// // This assumes that the process' user has "/home/jpetersen" as home directory.
 /// assert_eq!(
-///     "/home/jpetersen".as_ref(),
+///     std::path::Path::new("/home/jpetersen"),
 ///     get_my_home().unwrap().unwrap().as_path()
 /// );
 ///

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -27,7 +27,7 @@ pub type GetHomeError = nix::errno::Errno;
 /// // `/root` as a home directory.
 /// assert_eq!(
 ///     std::path::Path::new("/root"),
-///     get_home("root").unwrap().unwrap()
+///     get_home("root").unwrap().unwrap().as_path()
 /// );
 /// assert!(get_home("nonexistentuser").unwrap().is_none());
 /// ```


### PR DESCRIPTION
Closes #1 and also fixes the tests on unix